### PR TITLE
Implement Clone manually for Money and RawMoney

### DIFF
--- a/src/accounting/interest.rs
+++ b/src/accounting/interest.rs
@@ -62,7 +62,7 @@ pub trait InterestOps<C> {
 impl<M, C> InterestOps<C> for M
 where
     M: BaseMoney<C> + BaseOps<C> + Amount<C>,
-    C: Currency + Clone,
+    C: Currency,
 {
     type InterestBuilder<'a>
         = Interest<'a, M, C>

--- a/src/dec_ops.rs
+++ b/src/dec_ops.rs
@@ -6,7 +6,7 @@ use std::ops::{Add, Div, Mul, Rem, Sub};
 // Money + Decimal = Money
 impl<C> Add<Decimal> for Money<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     type Output = Self;
 
@@ -24,7 +24,7 @@ where
 // Money - Decimal = Money
 impl<C> Sub<Decimal> for Money<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     type Output = Self;
 
@@ -42,7 +42,7 @@ where
 // Money * Decimal = Money
 impl<C> Mul<Decimal> for Money<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     type Output = Self;
 
@@ -60,7 +60,7 @@ where
 // Money / Decimal = Money
 impl<C> Div<Decimal> for Money<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     type Output = Self;
 
@@ -78,7 +78,7 @@ where
 // Decimal + Money = Money
 impl<C> Add<Money<C>> for Decimal
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     type Output = Money<C>;
 
@@ -95,7 +95,7 @@ where
 // Decimal - Money = Money
 impl<C> Sub<Money<C>> for Decimal
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     type Output = Money<C>;
 
@@ -112,7 +112,7 @@ where
 // Decimal * Money = Money
 impl<C> Mul<Money<C>> for Decimal
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     type Output = Money<C>;
 
@@ -129,7 +129,7 @@ where
 // Decimal / Money = Money
 impl<C> Div<Money<C>> for Decimal
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     type Output = Money<C>;
 
@@ -145,7 +145,7 @@ where
 
 impl<C> Rem<Decimal> for Money<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     type Output = Money<C>;
 

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -113,7 +113,7 @@ pub trait Exchange<From: Currency> {
     /// // CAD is not in the rates, so None returned.
     /// assert!(money.convert::<CAD>(rates).is_none());
     /// ```
-    fn convert<To: Currency + Clone>(&self, rate: impl Rate<From, To>) -> Option<Self::Target<To>>
+    fn convert<To: Currency>(&self, rate: impl Rate<From, To>) -> Option<Self::Target<To>>
     where
         Self: Convert<To>;
 }
@@ -128,7 +128,7 @@ where
     where
         M: Convert<T>;
 
-    fn convert<To: Currency + Clone>(&self, rate: impl Rate<From, To>) -> Option<Self::Target<To>>
+    fn convert<To: Currency>(&self, rate: impl Rate<From, To>) -> Option<Self::Target<To>>
     where
         M: Convert<To>,
     {
@@ -146,11 +146,11 @@ pub trait Convert<T: Currency> {
     type Output: BaseMoney<T>;
 }
 
-impl<C: Currency, T: Currency + Clone> Convert<T> for Money<C> {
+impl<C: Currency, T: Currency> Convert<T> for Money<C> {
     type Output = Money<T>;
 }
 
-impl<C: Currency, T: Currency + Clone> Convert<T> for RawMoney<C> {
+impl<C: Currency, T: Currency> Convert<T> for RawMoney<C> {
     type Output = RawMoney<T>;
 }
 
@@ -168,26 +168,26 @@ impl<C: Currency, T: Currency + Clone> Convert<T> for RawMoney<C> {
 /// - i128
 /// - ExchangeRates<'a, C> where C is base currency of exchange rates
 ///
-pub trait Rate<From: Currency, To: Currency + Clone>: Amount<To> {
+pub trait Rate<From: Currency, To: Currency>: Amount<To> {
     /// Get T's rate relative to C.
     fn get_rate(&self) -> Option<Decimal> {
         self.get_decimal()
     }
 }
 
-impl<From: Currency, To: Currency + Clone> Rate<From, To> for Money<To> {}
+impl<From: Currency, To: Currency> Rate<From, To> for Money<To> {}
 
-impl<From: Currency, To: Currency + Clone> Rate<From, To> for RawMoney<To> {}
+impl<From: Currency, To: Currency> Rate<From, To> for RawMoney<To> {}
 
-impl<From: Currency, To: Currency + Clone> Rate<From, To> for Decimal {}
+impl<From: Currency, To: Currency> Rate<From, To> for Decimal {}
 
-impl<From: Currency, To: Currency + Clone> Rate<From, To> for f64 {}
+impl<From: Currency, To: Currency> Rate<From, To> for f64 {}
 
-impl<From: Currency, To: Currency + Clone> Rate<From, To> for i32 {}
+impl<From: Currency, To: Currency> Rate<From, To> for i32 {}
 
-impl<From: Currency, To: Currency + Clone> Rate<From, To> for i64 {}
+impl<From: Currency, To: Currency> Rate<From, To> for i64 {}
 
-impl<From: Currency, To: Currency + Clone> Rate<From, To> for i128 {}
+impl<From: Currency, To: Currency> Rate<From, To> for i128 {}
 
 // ========================= ExchangeRates =========================
 
@@ -235,7 +235,7 @@ pub struct ExchangeRates<'a, Base: Currency> {
     _base: PhantomData<Base>,
 }
 
-impl<'a, Base: Currency + Clone> ExchangeRates<'a, Base> {
+impl<'a, Base: Currency> ExchangeRates<'a, Base> {
     /// Initiate new ExchangeRates with base currency and 1 entry to the base with value 1.
     ///
     /// # Examples
@@ -364,7 +364,7 @@ impl<'a, Base: Currency + Clone> ExchangeRates<'a, Base> {
     }
 }
 
-impl<'a, I, Base: Currency + Clone> From<I> for ExchangeRates<'a, Base>
+impl<'a, I, Base: Currency> From<I> for ExchangeRates<'a, Base>
 where
     I: IntoIterator<Item = (&'a str, Decimal)>,
 {
@@ -380,7 +380,7 @@ where
     }
 }
 
-impl<'a, Base: Currency + Clone> Default for ExchangeRates<'a, Base> {
+impl<'a, Base: Currency> Default for ExchangeRates<'a, Base> {
     fn default() -> Self {
         Self::new()
     }
@@ -400,9 +400,9 @@ impl<'a, Base: Currency, To: Currency> Amount<To> for &ExchangeRates<'a, Base> {
 
 impl<'a, Base, From, To> Rate<From, To> for ExchangeRates<'a, Base>
 where
-    Base: Currency + Clone,
-    From: Currency + Clone,
-    To: Currency + Clone,
+    Base: Currency,
+    From: Currency,
+    To: Currency,
 {
     fn get_rate(&self) -> Option<Decimal> {
         self.get_pair(From::CODE, To::CODE)
@@ -411,9 +411,9 @@ where
 
 impl<'a, Base, From, To> Rate<From, To> for &ExchangeRates<'a, Base>
 where
-    Base: Currency + Clone,
-    From: Currency + Clone,
-    To: Currency + Clone,
+    Base: Currency,
+    From: Currency,
+    To: Currency,
 {
     fn get_rate(&self) -> Option<Decimal> {
         <ExchangeRates<Base> as Rate<From, To>>::get_rate(self)

--- a/src/money.rs
+++ b/src/money.rs
@@ -63,7 +63,7 @@ pub struct Money<C: Currency> {
 
 impl<C> Money<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     /// Creates a new `Money` instance from Decimal
     ///
@@ -350,7 +350,7 @@ where
 
 impl<C> Amount<C> for Money<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     fn get_decimal(&self) -> Option<Decimal> {
         Some(self.amount())
@@ -359,7 +359,7 @@ where
 
 impl<C> FromStr for Money<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     type Err = MoneyError;
 
@@ -413,7 +413,7 @@ impl<C: Currency> Clone for Money<C> {
 /// ```
 impl<C> Display for Money<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display())
@@ -429,7 +429,7 @@ where
     }
 }
 
-impl<C: Currency + Clone> Sum for Money<C> {
+impl<C: Currency> Sum for Money<C> {
     /// Sum all moneys
     ///
     /// WARN: PANIC!!! if overflowed.
@@ -438,7 +438,7 @@ impl<C: Currency + Clone> Sum for Money<C> {
     }
 }
 
-impl<'a, C: Currency + Clone> Sum<&'a Money<C>> for Money<C> {
+impl<'a, C: Currency> Sum<&'a Money<C>> for Money<C> {
     /// Sum all moneys(borrowed)
     ///
     /// WARN: PANIC!!! if overflowed.
@@ -449,7 +449,7 @@ impl<'a, C: Currency + Clone> Sum<&'a Money<C>> for Money<C> {
 
 impl<C> BaseMoney<C> for Money<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     #[inline]
     fn new(amount: impl DecimalNumber) -> Result<Self, MoneyError> {
@@ -496,7 +496,7 @@ where
 
 impl<C> BaseOps<C> for Money<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     #[inline]
     fn abs(&self) -> Self {
@@ -544,9 +544,9 @@ where
     }
 }
 
-impl<C> MoneyFormatter<C> for Money<C> where C: Currency + Clone {}
+impl<C> MoneyFormatter<C> for Money<C> where C: Currency {}
 
 #[cfg(feature = "accounting")]
-impl<C> AccountingOps<C> for Money<C> where C: Currency + Clone {}
+impl<C> AccountingOps<C> for Money<C> where C: Currency {}
 
-impl<C> MoneyOps<C> for Money<C> where C: Currency + Clone {}
+impl<C> MoneyOps<C> for Money<C> where C: Currency {}

--- a/src/money.rs
+++ b/src/money.rs
@@ -55,7 +55,7 @@ use rust_decimal::{MathematicalOps, prelude::FromPrimitive};
 /// - [`BaseMoney`] trait for core money operations and accessors
 /// - [`BaseOps`] trait for arithmetic and comparison operations
 /// - [`MoneyFormatter`] trait for custom formatting and rounding
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Copy, PartialEq, Eq)]
 pub struct Money<C: Currency> {
     amount: Decimal,
     _currency: PhantomData<C>,
@@ -379,6 +379,15 @@ where
         let s = s.trim();
         let dec_num = Decimal::from_str(s).map_err(|_| MoneyError::ParseStr)?;
         Ok(Self::from_decimal(dec_num))
+    }
+}
+
+impl<C: Currency> Clone for Money<C> {
+    fn clone(&self) -> Self {
+        Self {
+            amount: self.amount,
+            _currency: PhantomData,
+        }
     }
 }
 

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -9,7 +9,7 @@ use crate::{BaseMoney, Money};
 /// Money + Money = Money
 impl<C> Add for Money<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     type Output = Self;
 
@@ -27,7 +27,7 @@ where
 /// Money - Money = Money
 impl<C> Sub for Money<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     type Output = Self;
 
@@ -45,7 +45,7 @@ where
 /// Money * Money = Money
 impl<C> Mul for Money<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     type Output = Self;
 
@@ -63,7 +63,7 @@ where
 /// Money / Money = Money
 impl<C> Div for Money<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     type Output = Self;
 
@@ -81,7 +81,7 @@ where
 /// Money += Money
 impl<C> AddAssign for Money<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     fn add_assign(&mut self, other: Self) {
         // WARN: PANIC!
@@ -99,7 +99,7 @@ where
 /// Money -= Money
 impl<C> SubAssign for Money<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     fn sub_assign(&mut self, other: Self) {
         // WARN: PANIC!
@@ -117,7 +117,7 @@ where
 /// Money *= Money
 impl<C> MulAssign for Money<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     fn mul_assign(&mut self, other: Self) {
         // WARN: PANIC!
@@ -135,7 +135,7 @@ where
 /// Money /= Money
 impl<C> DivAssign for Money<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     fn div_assign(&mut self, other: Self) {
         // WARN: PANIC!
@@ -152,7 +152,7 @@ where
 
 impl<C> Neg for Money<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     type Output = Self;
 

--- a/src/raw_money/dec_ops.rs
+++ b/src/raw_money/dec_ops.rs
@@ -6,7 +6,7 @@ use super::RawMoney;
 // RawMoney + Decimal = RawMoney (no auto-rounding)
 impl<C> Add<Decimal> for RawMoney<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     type Output = Self;
 
@@ -24,7 +24,7 @@ where
 // RawMoney - Decimal = RawMoney (no auto-rounding)
 impl<C> Sub<Decimal> for RawMoney<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     type Output = Self;
 
@@ -42,7 +42,7 @@ where
 // RawMoney * Decimal = RawMoney (no auto-rounding)
 impl<C> Mul<Decimal> for RawMoney<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     type Output = Self;
 
@@ -60,7 +60,7 @@ where
 // RawMoney / Decimal = RawMoney (no auto-rounding)
 impl<C> Div<Decimal> for RawMoney<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     type Output = Self;
 
@@ -78,7 +78,7 @@ where
 // Decimal + RawMoney = RawMoney (no auto-rounding)
 impl<C> Add<RawMoney<C>> for Decimal
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     type Output = RawMoney<C>;
 
@@ -95,7 +95,7 @@ where
 // Decimal - RawMoney = RawMoney (no auto-rounding)
 impl<C> Sub<RawMoney<C>> for Decimal
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     type Output = RawMoney<C>;
 
@@ -112,7 +112,7 @@ where
 // Decimal * RawMoney = RawMoney (no auto-rounding)
 impl<C> Mul<RawMoney<C>> for Decimal
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     type Output = RawMoney<C>;
 
@@ -129,7 +129,7 @@ where
 // Decimal / RawMoney = RawMoney (no auto-rounding)
 impl<C> Div<RawMoney<C>> for Decimal
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     type Output = RawMoney<C>;
 
@@ -145,7 +145,7 @@ where
 
 impl<C> Rem<Decimal> for RawMoney<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     type Output = RawMoney<C>;
 

--- a/src/raw_money/money_ext.rs
+++ b/src/raw_money/money_ext.rs
@@ -4,7 +4,7 @@ use super::RawMoney;
 
 impl<C> Money<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     /// Converts this `Money` into `RawMoney`, preserving the current (rounded) amount.
     ///

--- a/src/raw_money/ops.rs
+++ b/src/raw_money/ops.rs
@@ -9,7 +9,7 @@ use super::RawMoney;
 /// RawMoney + RawMoney = RawMoney (no auto-rounding)
 impl<C> Add for RawMoney<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     type Output = Self;
 
@@ -27,7 +27,7 @@ where
 /// RawMoney - RawMoney = RawMoney (no auto-rounding)
 impl<C> Sub for RawMoney<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     type Output = Self;
 
@@ -45,7 +45,7 @@ where
 /// RawMoney * RawMoney = RawMoney (no auto-rounding)
 impl<C> Mul for RawMoney<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     type Output = Self;
 
@@ -63,7 +63,7 @@ where
 /// RawMoney / RawMoney = RawMoney (no auto-rounding)
 impl<C> Div for RawMoney<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     type Output = Self;
 
@@ -81,7 +81,7 @@ where
 /// RawMoney += RawMoney (no auto-rounding)
 impl<C> AddAssign for RawMoney<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     fn add_assign(&mut self, other: Self) {
         let ret = self
@@ -96,7 +96,7 @@ where
 /// RawMoney -= RawMoney (no auto-rounding)
 impl<C> SubAssign for RawMoney<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     fn sub_assign(&mut self, other: Self) {
         let ret = self
@@ -111,7 +111,7 @@ where
 /// RawMoney *= RawMoney (no auto-rounding)
 impl<C> MulAssign for RawMoney<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     fn mul_assign(&mut self, other: Self) {
         let ret = self
@@ -126,7 +126,7 @@ where
 /// RawMoney /= RawMoney (no auto-rounding)
 impl<C> DivAssign for RawMoney<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     fn div_assign(&mut self, other: Self) {
         let ret = self
@@ -141,7 +141,7 @@ where
 /// Negation: -RawMoney = RawMoney
 impl<C> Neg for RawMoney<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     type Output = Self;
 

--- a/src/raw_money/raw_money.rs
+++ b/src/raw_money/raw_money.rs
@@ -79,7 +79,7 @@ pub struct RawMoney<C: Currency> {
 
 impl<C> RawMoney<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     /// Creates a new `RawMoney` instance from Decimal without rounding.
     ///
@@ -343,7 +343,7 @@ where
 
 impl<C> Amount<C> for RawMoney<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     fn get_decimal(&self) -> Option<Decimal> {
         Some(self.amount())
@@ -352,7 +352,7 @@ where
 
 impl<C> FromStr for RawMoney<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     type Err = MoneyError;
 
@@ -399,7 +399,7 @@ impl<C: Currency> Clone for RawMoney<C> {
 /// ```
 impl<C> Display for RawMoney<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display())
@@ -415,7 +415,7 @@ where
     }
 }
 
-impl<C: Currency + Clone> Sum for RawMoney<C> {
+impl<C: Currency> Sum for RawMoney<C> {
     /// Sum all moneys
     ///
     /// WARN: PANIC! if overflowed.
@@ -424,7 +424,7 @@ impl<C: Currency + Clone> Sum for RawMoney<C> {
     }
 }
 
-impl<'a, C: Currency + Clone> Sum<&'a RawMoney<C>> for RawMoney<C> {
+impl<'a, C: Currency> Sum<&'a RawMoney<C>> for RawMoney<C> {
     /// Sum all moneys(borrowed)
     ///
     /// WARN: PANIC!!! if overflowed.
@@ -435,7 +435,7 @@ impl<'a, C: Currency + Clone> Sum<&'a RawMoney<C>> for RawMoney<C> {
 
 impl<C> BaseMoney<C> for RawMoney<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     #[inline]
     fn new(amount: impl DecimalNumber) -> Result<Self, MoneyError> {
@@ -529,7 +529,7 @@ where
 
 impl<C> BaseOps<C> for RawMoney<C>
 where
-    C: Currency + Clone,
+    C: Currency,
 {
     #[inline]
     fn abs(&self) -> Self {
@@ -577,9 +577,9 @@ where
     }
 }
 
-impl<C> MoneyFormatter<C> for RawMoney<C> where C: Currency + Clone {}
+impl<C> MoneyFormatter<C> for RawMoney<C> where C: Currency {}
 
 #[cfg(feature = "accounting")]
-impl<C> AccountingOps<C> for RawMoney<C> where C: Currency + Clone {}
+impl<C> AccountingOps<C> for RawMoney<C> where C: Currency {}
 
-impl<C> MoneyOps<C> for RawMoney<C> where C: Currency + Clone {}
+impl<C> MoneyOps<C> for RawMoney<C> where C: Currency {}

--- a/src/raw_money/raw_money.rs
+++ b/src/raw_money/raw_money.rs
@@ -71,7 +71,7 @@ use rust_decimal::{MathematicalOps, prelude::FromPrimitive, prelude::ToPrimitive
 /// - [`BaseMoney`] trait for core money operations and accessors
 /// - [`BaseOps`] trait for arithmetic and comparison operations
 /// - [`MoneyFormatter`] trait for custom formatting and rounding
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Copy, PartialEq, Eq)]
 pub struct RawMoney<C: Currency> {
     amount: Decimal,
     _currency: PhantomData<C>,
@@ -372,6 +372,15 @@ where
         let s = s.trim();
         let dec_num = Decimal::from_str(s).map_err(|_| MoneyError::ParseStr)?;
         Ok(Self::from_decimal(dec_num))
+    }
+}
+
+impl<C: Currency> Clone for RawMoney<C> {
+    fn clone(&self) -> Self {
+        Self {
+            amount: self.amount,
+            _currency: PhantomData,
+        }
     }
 }
 

--- a/src/serde/money.rs
+++ b/src/serde/money.rs
@@ -10,7 +10,7 @@ use crate::{BaseMoney, Currency, Decimal, Money};
 // Default: Serialize/Deserialize as precise number
 // ---------------------------------------------------------------------------
 
-impl<C: Currency + Clone> Serialize for Money<C> {
+impl<C: Currency> Serialize for Money<C> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let n = serde_json::Number::from_str(&self.amount().to_string())
             .map_err(|_| ::serde::ser::Error::custom("cannot convert Decimal to JSON Number"))?;
@@ -20,7 +20,7 @@ impl<C: Currency + Clone> Serialize for Money<C> {
 
 struct MoneyVisitor<C>(PhantomData<C>);
 
-impl<'de, C: Currency + Clone> de::Visitor<'de> for MoneyVisitor<C> {
+impl<'de, C: Currency> de::Visitor<'de> for MoneyVisitor<C> {
     type Value = Money<C>;
 
     fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -70,7 +70,7 @@ impl<'de, C: Currency + Clone> de::Visitor<'de> for MoneyVisitor<C> {
     }
 }
 
-impl<'de, C: Currency + Clone> Deserialize<'de> for Money<C> {
+impl<'de, C: Currency> Deserialize<'de> for Money<C> {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         deserializer.deserialize_any(MoneyVisitor(PhantomData))
     }
@@ -100,7 +100,7 @@ pub mod comma_str_code {
 
     use crate::{Currency, Money, MoneyFormatter};
 
-    pub fn serialize<C: Currency + Clone, S: Serializer>(
+    pub fn serialize<C: Currency, S: Serializer>(
         value: &Money<C>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
@@ -109,7 +109,7 @@ pub mod comma_str_code {
 
     struct Visitor<C>(PhantomData<C>);
 
-    impl<'de, C: Currency + Clone> de::Visitor<'de> for Visitor<C> {
+    impl<'de, C: Currency> de::Visitor<'de> for Visitor<C> {
         type Value = Money<C>;
 
         fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -121,7 +121,7 @@ pub mod comma_str_code {
         }
     }
 
-    pub fn deserialize<'de, C: Currency + Clone, D: Deserializer<'de>>(
+    pub fn deserialize<'de, C: Currency, D: Deserializer<'de>>(
         deserializer: D,
     ) -> Result<Money<C>, D::Error> {
         deserializer.deserialize_str(Visitor(PhantomData))
@@ -148,7 +148,7 @@ pub mod option_comma_str_code {
 
     use crate::{BaseMoney, Currency, Money};
 
-    pub fn serialize<C: Currency + Clone, S: Serializer>(
+    pub fn serialize<C: Currency, S: Serializer>(
         value: &Option<Money<C>>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
@@ -160,7 +160,7 @@ pub mod option_comma_str_code {
 
     struct Visitor<C>(PhantomData<C>);
 
-    impl<'de, C: Currency + Clone> de::Visitor<'de> for Visitor<C> {
+    impl<'de, C: Currency> de::Visitor<'de> for Visitor<C> {
         type Value = Option<Money<C>>;
 
         fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -180,7 +180,7 @@ pub mod option_comma_str_code {
         }
     }
 
-    pub fn deserialize<'de, C: Currency + Clone, D: Deserializer<'de>>(
+    pub fn deserialize<'de, C: Currency, D: Deserializer<'de>>(
         deserializer: D,
     ) -> Result<Option<Money<C>>, D::Error> {
         deserializer.deserialize_option(Visitor(PhantomData))
@@ -211,7 +211,7 @@ pub mod comma_str_symbol {
 
     use crate::{Currency, Money, MoneyFormatter};
 
-    pub fn serialize<C: Currency + Clone, S: Serializer>(
+    pub fn serialize<C: Currency, S: Serializer>(
         value: &Money<C>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
@@ -220,7 +220,7 @@ pub mod comma_str_symbol {
 
     struct Visitor<C>(PhantomData<C>);
 
-    impl<'de, C: Currency + Clone> de::Visitor<'de> for Visitor<C> {
+    impl<'de, C: Currency> de::Visitor<'de> for Visitor<C> {
         type Value = Money<C>;
 
         fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -232,7 +232,7 @@ pub mod comma_str_symbol {
         }
     }
 
-    pub fn deserialize<'de, C: Currency + Clone, D: Deserializer<'de>>(
+    pub fn deserialize<'de, C: Currency, D: Deserializer<'de>>(
         deserializer: D,
     ) -> Result<Money<C>, D::Error> {
         deserializer.deserialize_str(Visitor(PhantomData))
@@ -259,7 +259,7 @@ pub mod option_comma_str_symbol {
 
     use crate::{BaseMoney, Currency, Money};
 
-    pub fn serialize<C: Currency + Clone, S: Serializer>(
+    pub fn serialize<C: Currency, S: Serializer>(
         value: &Option<Money<C>>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
@@ -271,7 +271,7 @@ pub mod option_comma_str_symbol {
 
     struct Visitor<C>(PhantomData<C>);
 
-    impl<'de, C: Currency + Clone> de::Visitor<'de> for Visitor<C> {
+    impl<'de, C: Currency> de::Visitor<'de> for Visitor<C> {
         type Value = Option<Money<C>>;
 
         fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -291,7 +291,7 @@ pub mod option_comma_str_symbol {
         }
     }
 
-    pub fn deserialize<'de, C: Currency + Clone, D: Deserializer<'de>>(
+    pub fn deserialize<'de, C: Currency, D: Deserializer<'de>>(
         deserializer: D,
     ) -> Result<Option<Money<C>>, D::Error> {
         deserializer.deserialize_option(Visitor(PhantomData))
@@ -322,7 +322,7 @@ pub mod dot_str_code {
 
     use crate::{Currency, Money, MoneyFormatter};
 
-    pub fn serialize<C: Currency + Clone, S: Serializer>(
+    pub fn serialize<C: Currency, S: Serializer>(
         value: &Money<C>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
@@ -331,7 +331,7 @@ pub mod dot_str_code {
 
     struct Visitor<C>(PhantomData<C>);
 
-    impl<'de, C: Currency + Clone> de::Visitor<'de> for Visitor<C> {
+    impl<'de, C: Currency> de::Visitor<'de> for Visitor<C> {
         type Value = Money<C>;
 
         fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -343,7 +343,7 @@ pub mod dot_str_code {
         }
     }
 
-    pub fn deserialize<'de, C: Currency + Clone, D: Deserializer<'de>>(
+    pub fn deserialize<'de, C: Currency, D: Deserializer<'de>>(
         deserializer: D,
     ) -> Result<Money<C>, D::Error> {
         deserializer.deserialize_str(Visitor(PhantomData))
@@ -370,7 +370,7 @@ pub mod option_dot_str_code {
 
     use crate::{BaseMoney, Currency, Money};
 
-    pub fn serialize<C: Currency + Clone, S: Serializer>(
+    pub fn serialize<C: Currency, S: Serializer>(
         value: &Option<Money<C>>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
@@ -382,7 +382,7 @@ pub mod option_dot_str_code {
 
     struct Visitor<C>(PhantomData<C>);
 
-    impl<'de, C: Currency + Clone> de::Visitor<'de> for Visitor<C> {
+    impl<'de, C: Currency> de::Visitor<'de> for Visitor<C> {
         type Value = Option<Money<C>>;
 
         fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -402,7 +402,7 @@ pub mod option_dot_str_code {
         }
     }
 
-    pub fn deserialize<'de, C: Currency + Clone, D: Deserializer<'de>>(
+    pub fn deserialize<'de, C: Currency, D: Deserializer<'de>>(
         deserializer: D,
     ) -> Result<Option<Money<C>>, D::Error> {
         deserializer.deserialize_option(Visitor(PhantomData))
@@ -433,7 +433,7 @@ pub mod dot_str_symbol {
 
     use crate::{Currency, Money, MoneyFormatter};
 
-    pub fn serialize<C: Currency + Clone, S: Serializer>(
+    pub fn serialize<C: Currency, S: Serializer>(
         value: &Money<C>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
@@ -442,7 +442,7 @@ pub mod dot_str_symbol {
 
     struct Visitor<C>(PhantomData<C>);
 
-    impl<'de, C: Currency + Clone> de::Visitor<'de> for Visitor<C> {
+    impl<'de, C: Currency> de::Visitor<'de> for Visitor<C> {
         type Value = Money<C>;
 
         fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -454,7 +454,7 @@ pub mod dot_str_symbol {
         }
     }
 
-    pub fn deserialize<'de, C: Currency + Clone, D: Deserializer<'de>>(
+    pub fn deserialize<'de, C: Currency, D: Deserializer<'de>>(
         deserializer: D,
     ) -> Result<Money<C>, D::Error> {
         deserializer.deserialize_str(Visitor(PhantomData))
@@ -481,7 +481,7 @@ pub mod option_dot_str_symbol {
 
     use crate::{BaseMoney, Currency, Money};
 
-    pub fn serialize<C: Currency + Clone, S: Serializer>(
+    pub fn serialize<C: Currency, S: Serializer>(
         value: &Option<Money<C>>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
@@ -493,7 +493,7 @@ pub mod option_dot_str_symbol {
 
     struct Visitor<C>(PhantomData<C>);
 
-    impl<'de, C: Currency + Clone> de::Visitor<'de> for Visitor<C> {
+    impl<'de, C: Currency> de::Visitor<'de> for Visitor<C> {
         type Value = Option<Money<C>>;
 
         fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -513,7 +513,7 @@ pub mod option_dot_str_symbol {
         }
     }
 
-    pub fn deserialize<'de, C: Currency + Clone, D: Deserializer<'de>>(
+    pub fn deserialize<'de, C: Currency, D: Deserializer<'de>>(
         deserializer: D,
     ) -> Result<Option<Money<C>>, D::Error> {
         deserializer.deserialize_option(Visitor(PhantomData))
@@ -540,7 +540,7 @@ pub mod str_code {
 
     use crate::{BaseMoney, Currency, Money};
 
-    pub fn serialize<C: Currency + Clone, S: Serializer>(
+    pub fn serialize<C: Currency, S: Serializer>(
         value: &Money<C>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
@@ -549,7 +549,7 @@ pub mod str_code {
 
     struct Visitor<C>(PhantomData<C>);
 
-    impl<'de, C: Currency + Clone> de::Visitor<'de> for Visitor<C> {
+    impl<'de, C: Currency> de::Visitor<'de> for Visitor<C> {
         type Value = Money<C>;
 
         fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -561,7 +561,7 @@ pub mod str_code {
         }
     }
 
-    pub fn deserialize<'de, C: Currency + Clone, D: Deserializer<'de>>(
+    pub fn deserialize<'de, C: Currency, D: Deserializer<'de>>(
         deserializer: D,
     ) -> Result<Money<C>, D::Error> {
         deserializer.deserialize_str(Visitor(PhantomData))
@@ -585,7 +585,7 @@ pub mod option_str_code {
 
     use crate::{BaseMoney, Currency, Money};
 
-    pub fn serialize<C: Currency + Clone, S: Serializer>(
+    pub fn serialize<C: Currency, S: Serializer>(
         value: &Option<Money<C>>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
@@ -597,7 +597,7 @@ pub mod option_str_code {
 
     struct Visitor<C>(PhantomData<C>);
 
-    impl<'de, C: Currency + Clone> de::Visitor<'de> for Visitor<C> {
+    impl<'de, C: Currency> de::Visitor<'de> for Visitor<C> {
         type Value = Option<Money<C>>;
 
         fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -617,7 +617,7 @@ pub mod option_str_code {
         }
     }
 
-    pub fn deserialize<'de, C: Currency + Clone, D: Deserializer<'de>>(
+    pub fn deserialize<'de, C: Currency, D: Deserializer<'de>>(
         deserializer: D,
     ) -> Result<Option<Money<C>>, D::Error> {
         deserializer.deserialize_option(Visitor(PhantomData))
@@ -644,7 +644,7 @@ pub mod str_symbol {
 
     use crate::{BaseMoney, Currency, Money};
 
-    pub fn serialize<C: Currency + Clone, S: Serializer>(
+    pub fn serialize<C: Currency, S: Serializer>(
         value: &Money<C>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
@@ -653,7 +653,7 @@ pub mod str_symbol {
 
     struct Visitor<C>(PhantomData<C>);
 
-    impl<'de, C: Currency + Clone> de::Visitor<'de> for Visitor<C> {
+    impl<'de, C: Currency> de::Visitor<'de> for Visitor<C> {
         type Value = Money<C>;
 
         fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -665,7 +665,7 @@ pub mod str_symbol {
         }
     }
 
-    pub fn deserialize<'de, C: Currency + Clone, D: Deserializer<'de>>(
+    pub fn deserialize<'de, C: Currency, D: Deserializer<'de>>(
         deserializer: D,
     ) -> Result<Money<C>, D::Error> {
         deserializer.deserialize_str(Visitor(PhantomData))
@@ -689,7 +689,7 @@ pub mod option_str_symbol {
 
     use crate::{BaseMoney, Currency, Money};
 
-    pub fn serialize<C: Currency + Clone, S: Serializer>(
+    pub fn serialize<C: Currency, S: Serializer>(
         value: &Option<Money<C>>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
@@ -701,7 +701,7 @@ pub mod option_str_symbol {
 
     struct Visitor<C>(PhantomData<C>);
 
-    impl<'de, C: Currency + Clone> de::Visitor<'de> for Visitor<C> {
+    impl<'de, C: Currency> de::Visitor<'de> for Visitor<C> {
         type Value = Option<Money<C>>;
 
         fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -721,7 +721,7 @@ pub mod option_str_symbol {
         }
     }
 
-    pub fn deserialize<'de, C: Currency + Clone, D: Deserializer<'de>>(
+    pub fn deserialize<'de, C: Currency, D: Deserializer<'de>>(
         deserializer: D,
     ) -> Result<Option<Money<C>>, D::Error> {
         deserializer.deserialize_option(Visitor(PhantomData))
@@ -748,7 +748,7 @@ pub mod minor {
 
     use crate::{BaseMoney, Currency, Money};
 
-    pub fn serialize<C: Currency + Clone, S: Serializer>(
+    pub fn serialize<C: Currency, S: Serializer>(
         value: &Money<C>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
@@ -758,7 +758,7 @@ pub mod minor {
 
     struct Visitor<C>(PhantomData<C>);
 
-    impl<'de, C: Currency + Clone> de::Visitor<'de> for Visitor<C> {
+    impl<'de, C: Currency> de::Visitor<'de> for Visitor<C> {
         type Value = Money<C>;
 
         fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -784,7 +784,7 @@ pub mod minor {
         }
     }
 
-    pub fn deserialize<'de, C: Currency + Clone, D: Deserializer<'de>>(
+    pub fn deserialize<'de, C: Currency, D: Deserializer<'de>>(
         deserializer: D,
     ) -> Result<Money<C>, D::Error> {
         deserializer.deserialize_any(Visitor(PhantomData))
@@ -807,7 +807,7 @@ pub mod option_minor {
 
     use crate::{Currency, Money};
 
-    pub fn serialize<C: Currency + Clone, S: Serializer>(
+    pub fn serialize<C: Currency, S: Serializer>(
         value: &Option<Money<C>>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
@@ -819,7 +819,7 @@ pub mod option_minor {
 
     struct Visitor<C>(PhantomData<C>);
 
-    impl<'de, C: Currency + Clone> de::Visitor<'de> for Visitor<C> {
+    impl<'de, C: Currency> de::Visitor<'de> for Visitor<C> {
         type Value = Option<Money<C>>;
 
         fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -839,7 +839,7 @@ pub mod option_minor {
         }
     }
 
-    pub fn deserialize<'de, C: Currency + Clone, D: Deserializer<'de>>(
+    pub fn deserialize<'de, C: Currency, D: Deserializer<'de>>(
         deserializer: D,
     ) -> Result<Option<Money<C>>, D::Error> {
         deserializer.deserialize_option(Visitor(PhantomData))

--- a/src/serde/raw_money.rs
+++ b/src/serde/raw_money.rs
@@ -10,7 +10,7 @@ use crate::{BaseMoney, Currency, Decimal, RawMoney};
 // Default: Serialize/Deserialize as precise number
 // ---------------------------------------------------------------------------
 
-impl<C: Currency + Clone> Serialize for RawMoney<C> {
+impl<C: Currency> Serialize for RawMoney<C> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let n = serde_json::Number::from_str(&self.amount().to_string())
             .map_err(|_| ::serde::ser::Error::custom("cannot convert Decimal to JSON Number"))?;
@@ -20,7 +20,7 @@ impl<C: Currency + Clone> Serialize for RawMoney<C> {
 
 struct RawMoneyVisitor<C>(PhantomData<C>);
 
-impl<'de, C: Currency + Clone> de::Visitor<'de> for RawMoneyVisitor<C> {
+impl<'de, C: Currency> de::Visitor<'de> for RawMoneyVisitor<C> {
     type Value = RawMoney<C>;
 
     fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -70,7 +70,7 @@ impl<'de, C: Currency + Clone> de::Visitor<'de> for RawMoneyVisitor<C> {
     }
 }
 
-impl<'de, C: Currency + Clone> Deserialize<'de> for RawMoney<C> {
+impl<'de, C: Currency> Deserialize<'de> for RawMoney<C> {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         deserializer.deserialize_any(RawMoneyVisitor(PhantomData))
     }
@@ -100,7 +100,7 @@ pub mod comma_str_code {
 
     use crate::{Currency, MoneyFormatter, RawMoney};
 
-    pub fn serialize<C: Currency + Clone, S: Serializer>(
+    pub fn serialize<C: Currency, S: Serializer>(
         value: &RawMoney<C>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
@@ -109,7 +109,7 @@ pub mod comma_str_code {
 
     struct Visitor<C>(PhantomData<C>);
 
-    impl<'de, C: Currency + Clone> de::Visitor<'de> for Visitor<C> {
+    impl<'de, C: Currency> de::Visitor<'de> for Visitor<C> {
         type Value = RawMoney<C>;
 
         fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -121,7 +121,7 @@ pub mod comma_str_code {
         }
     }
 
-    pub fn deserialize<'de, C: Currency + Clone, D: Deserializer<'de>>(
+    pub fn deserialize<'de, C: Currency, D: Deserializer<'de>>(
         deserializer: D,
     ) -> Result<RawMoney<C>, D::Error> {
         deserializer.deserialize_str(Visitor(PhantomData))
@@ -148,7 +148,7 @@ pub mod option_comma_str_code {
 
     use crate::{BaseMoney, Currency, RawMoney};
 
-    pub fn serialize<C: Currency + Clone, S: Serializer>(
+    pub fn serialize<C: Currency, S: Serializer>(
         value: &Option<RawMoney<C>>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
@@ -160,7 +160,7 @@ pub mod option_comma_str_code {
 
     struct Visitor<C>(PhantomData<C>);
 
-    impl<'de, C: Currency + Clone> de::Visitor<'de> for Visitor<C> {
+    impl<'de, C: Currency> de::Visitor<'de> for Visitor<C> {
         type Value = Option<RawMoney<C>>;
 
         fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -180,7 +180,7 @@ pub mod option_comma_str_code {
         }
     }
 
-    pub fn deserialize<'de, C: Currency + Clone, D: Deserializer<'de>>(
+    pub fn deserialize<'de, C: Currency, D: Deserializer<'de>>(
         deserializer: D,
     ) -> Result<Option<RawMoney<C>>, D::Error> {
         deserializer.deserialize_option(Visitor(PhantomData))
@@ -211,7 +211,7 @@ pub mod comma_str_symbol {
 
     use crate::{Currency, MoneyFormatter, RawMoney};
 
-    pub fn serialize<C: Currency + Clone, S: Serializer>(
+    pub fn serialize<C: Currency, S: Serializer>(
         value: &RawMoney<C>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
@@ -220,7 +220,7 @@ pub mod comma_str_symbol {
 
     struct Visitor<C>(PhantomData<C>);
 
-    impl<'de, C: Currency + Clone> de::Visitor<'de> for Visitor<C> {
+    impl<'de, C: Currency> de::Visitor<'de> for Visitor<C> {
         type Value = RawMoney<C>;
 
         fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -232,7 +232,7 @@ pub mod comma_str_symbol {
         }
     }
 
-    pub fn deserialize<'de, C: Currency + Clone, D: Deserializer<'de>>(
+    pub fn deserialize<'de, C: Currency, D: Deserializer<'de>>(
         deserializer: D,
     ) -> Result<RawMoney<C>, D::Error> {
         deserializer.deserialize_str(Visitor(PhantomData))
@@ -259,7 +259,7 @@ pub mod option_comma_str_symbol {
 
     use crate::{BaseMoney, Currency, RawMoney};
 
-    pub fn serialize<C: Currency + Clone, S: Serializer>(
+    pub fn serialize<C: Currency, S: Serializer>(
         value: &Option<RawMoney<C>>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
@@ -271,7 +271,7 @@ pub mod option_comma_str_symbol {
 
     struct Visitor<C>(PhantomData<C>);
 
-    impl<'de, C: Currency + Clone> de::Visitor<'de> for Visitor<C> {
+    impl<'de, C: Currency> de::Visitor<'de> for Visitor<C> {
         type Value = Option<RawMoney<C>>;
 
         fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -291,7 +291,7 @@ pub mod option_comma_str_symbol {
         }
     }
 
-    pub fn deserialize<'de, C: Currency + Clone, D: Deserializer<'de>>(
+    pub fn deserialize<'de, C: Currency, D: Deserializer<'de>>(
         deserializer: D,
     ) -> Result<Option<RawMoney<C>>, D::Error> {
         deserializer.deserialize_option(Visitor(PhantomData))
@@ -322,7 +322,7 @@ pub mod dot_str_code {
 
     use crate::{Currency, MoneyFormatter, RawMoney};
 
-    pub fn serialize<C: Currency + Clone, S: Serializer>(
+    pub fn serialize<C: Currency, S: Serializer>(
         value: &RawMoney<C>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
@@ -331,7 +331,7 @@ pub mod dot_str_code {
 
     struct Visitor<C>(PhantomData<C>);
 
-    impl<'de, C: Currency + Clone> de::Visitor<'de> for Visitor<C> {
+    impl<'de, C: Currency> de::Visitor<'de> for Visitor<C> {
         type Value = RawMoney<C>;
 
         fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -343,7 +343,7 @@ pub mod dot_str_code {
         }
     }
 
-    pub fn deserialize<'de, C: Currency + Clone, D: Deserializer<'de>>(
+    pub fn deserialize<'de, C: Currency, D: Deserializer<'de>>(
         deserializer: D,
     ) -> Result<RawMoney<C>, D::Error> {
         deserializer.deserialize_str(Visitor(PhantomData))
@@ -370,7 +370,7 @@ pub mod option_dot_str_code {
 
     use crate::{BaseMoney, Currency, RawMoney};
 
-    pub fn serialize<C: Currency + Clone, S: Serializer>(
+    pub fn serialize<C: Currency, S: Serializer>(
         value: &Option<RawMoney<C>>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
@@ -382,7 +382,7 @@ pub mod option_dot_str_code {
 
     struct Visitor<C>(PhantomData<C>);
 
-    impl<'de, C: Currency + Clone> de::Visitor<'de> for Visitor<C> {
+    impl<'de, C: Currency> de::Visitor<'de> for Visitor<C> {
         type Value = Option<RawMoney<C>>;
 
         fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -402,7 +402,7 @@ pub mod option_dot_str_code {
         }
     }
 
-    pub fn deserialize<'de, C: Currency + Clone, D: Deserializer<'de>>(
+    pub fn deserialize<'de, C: Currency, D: Deserializer<'de>>(
         deserializer: D,
     ) -> Result<Option<RawMoney<C>>, D::Error> {
         deserializer.deserialize_option(Visitor(PhantomData))
@@ -433,7 +433,7 @@ pub mod dot_str_symbol {
 
     use crate::{Currency, MoneyFormatter, RawMoney};
 
-    pub fn serialize<C: Currency + Clone, S: Serializer>(
+    pub fn serialize<C: Currency, S: Serializer>(
         value: &RawMoney<C>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
@@ -442,7 +442,7 @@ pub mod dot_str_symbol {
 
     struct Visitor<C>(PhantomData<C>);
 
-    impl<'de, C: Currency + Clone> de::Visitor<'de> for Visitor<C> {
+    impl<'de, C: Currency> de::Visitor<'de> for Visitor<C> {
         type Value = RawMoney<C>;
 
         fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -454,7 +454,7 @@ pub mod dot_str_symbol {
         }
     }
 
-    pub fn deserialize<'de, C: Currency + Clone, D: Deserializer<'de>>(
+    pub fn deserialize<'de, C: Currency, D: Deserializer<'de>>(
         deserializer: D,
     ) -> Result<RawMoney<C>, D::Error> {
         deserializer.deserialize_str(Visitor(PhantomData))
@@ -481,7 +481,7 @@ pub mod option_dot_str_symbol {
 
     use crate::{BaseMoney, Currency, RawMoney};
 
-    pub fn serialize<C: Currency + Clone, S: Serializer>(
+    pub fn serialize<C: Currency, S: Serializer>(
         value: &Option<RawMoney<C>>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
@@ -493,7 +493,7 @@ pub mod option_dot_str_symbol {
 
     struct Visitor<C>(PhantomData<C>);
 
-    impl<'de, C: Currency + Clone> de::Visitor<'de> for Visitor<C> {
+    impl<'de, C: Currency> de::Visitor<'de> for Visitor<C> {
         type Value = Option<RawMoney<C>>;
 
         fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -513,7 +513,7 @@ pub mod option_dot_str_symbol {
         }
     }
 
-    pub fn deserialize<'de, C: Currency + Clone, D: Deserializer<'de>>(
+    pub fn deserialize<'de, C: Currency, D: Deserializer<'de>>(
         deserializer: D,
     ) -> Result<Option<RawMoney<C>>, D::Error> {
         deserializer.deserialize_option(Visitor(PhantomData))
@@ -540,7 +540,7 @@ pub mod str_code {
 
     use crate::{BaseMoney, Currency, RawMoney};
 
-    pub fn serialize<C: Currency + Clone, S: Serializer>(
+    pub fn serialize<C: Currency, S: Serializer>(
         value: &RawMoney<C>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
@@ -549,7 +549,7 @@ pub mod str_code {
 
     struct Visitor<C>(PhantomData<C>);
 
-    impl<'de, C: Currency + Clone> de::Visitor<'de> for Visitor<C> {
+    impl<'de, C: Currency> de::Visitor<'de> for Visitor<C> {
         type Value = RawMoney<C>;
 
         fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -561,7 +561,7 @@ pub mod str_code {
         }
     }
 
-    pub fn deserialize<'de, C: Currency + Clone, D: Deserializer<'de>>(
+    pub fn deserialize<'de, C: Currency, D: Deserializer<'de>>(
         deserializer: D,
     ) -> Result<RawMoney<C>, D::Error> {
         deserializer.deserialize_str(Visitor(PhantomData))
@@ -585,7 +585,7 @@ pub mod option_str_code {
 
     use crate::{BaseMoney, Currency, RawMoney};
 
-    pub fn serialize<C: Currency + Clone, S: Serializer>(
+    pub fn serialize<C: Currency, S: Serializer>(
         value: &Option<RawMoney<C>>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
@@ -597,7 +597,7 @@ pub mod option_str_code {
 
     struct Visitor<C>(PhantomData<C>);
 
-    impl<'de, C: Currency + Clone> de::Visitor<'de> for Visitor<C> {
+    impl<'de, C: Currency> de::Visitor<'de> for Visitor<C> {
         type Value = Option<RawMoney<C>>;
 
         fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -617,7 +617,7 @@ pub mod option_str_code {
         }
     }
 
-    pub fn deserialize<'de, C: Currency + Clone, D: Deserializer<'de>>(
+    pub fn deserialize<'de, C: Currency, D: Deserializer<'de>>(
         deserializer: D,
     ) -> Result<Option<RawMoney<C>>, D::Error> {
         deserializer.deserialize_option(Visitor(PhantomData))
@@ -644,7 +644,7 @@ pub mod str_symbol {
 
     use crate::{BaseMoney, Currency, RawMoney};
 
-    pub fn serialize<C: Currency + Clone, S: Serializer>(
+    pub fn serialize<C: Currency, S: Serializer>(
         value: &RawMoney<C>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
@@ -653,7 +653,7 @@ pub mod str_symbol {
 
     struct Visitor<C>(PhantomData<C>);
 
-    impl<'de, C: Currency + Clone> de::Visitor<'de> for Visitor<C> {
+    impl<'de, C: Currency> de::Visitor<'de> for Visitor<C> {
         type Value = RawMoney<C>;
 
         fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -665,7 +665,7 @@ pub mod str_symbol {
         }
     }
 
-    pub fn deserialize<'de, C: Currency + Clone, D: Deserializer<'de>>(
+    pub fn deserialize<'de, C: Currency, D: Deserializer<'de>>(
         deserializer: D,
     ) -> Result<RawMoney<C>, D::Error> {
         deserializer.deserialize_str(Visitor(PhantomData))
@@ -689,7 +689,7 @@ pub mod option_str_symbol {
 
     use crate::{BaseMoney, Currency, RawMoney};
 
-    pub fn serialize<C: Currency + Clone, S: Serializer>(
+    pub fn serialize<C: Currency, S: Serializer>(
         value: &Option<RawMoney<C>>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
@@ -701,7 +701,7 @@ pub mod option_str_symbol {
 
     struct Visitor<C>(PhantomData<C>);
 
-    impl<'de, C: Currency + Clone> de::Visitor<'de> for Visitor<C> {
+    impl<'de, C: Currency> de::Visitor<'de> for Visitor<C> {
         type Value = Option<RawMoney<C>>;
 
         fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -721,7 +721,7 @@ pub mod option_str_symbol {
         }
     }
 
-    pub fn deserialize<'de, C: Currency + Clone, D: Deserializer<'de>>(
+    pub fn deserialize<'de, C: Currency, D: Deserializer<'de>>(
         deserializer: D,
     ) -> Result<Option<RawMoney<C>>, D::Error> {
         deserializer.deserialize_option(Visitor(PhantomData))
@@ -748,7 +748,7 @@ pub mod minor {
 
     use crate::{BaseMoney, Currency, RawMoney};
 
-    pub fn serialize<C: Currency + Clone, S: Serializer>(
+    pub fn serialize<C: Currency, S: Serializer>(
         value: &RawMoney<C>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
@@ -758,7 +758,7 @@ pub mod minor {
 
     struct Visitor<C>(PhantomData<C>);
 
-    impl<'de, C: Currency + Clone> de::Visitor<'de> for Visitor<C> {
+    impl<'de, C: Currency> de::Visitor<'de> for Visitor<C> {
         type Value = RawMoney<C>;
 
         fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -784,7 +784,7 @@ pub mod minor {
         }
     }
 
-    pub fn deserialize<'de, C: Currency + Clone, D: Deserializer<'de>>(
+    pub fn deserialize<'de, C: Currency, D: Deserializer<'de>>(
         deserializer: D,
     ) -> Result<RawMoney<C>, D::Error> {
         deserializer.deserialize_any(Visitor(PhantomData))
@@ -807,7 +807,7 @@ pub mod option_minor {
 
     use crate::{Currency, RawMoney};
 
-    pub fn serialize<C: Currency + Clone, S: Serializer>(
+    pub fn serialize<C: Currency, S: Serializer>(
         value: &Option<RawMoney<C>>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
@@ -819,7 +819,7 @@ pub mod option_minor {
 
     struct Visitor<C>(PhantomData<C>);
 
-    impl<'de, C: Currency + Clone> de::Visitor<'de> for Visitor<C> {
+    impl<'de, C: Currency> de::Visitor<'de> for Visitor<C> {
         type Value = Option<RawMoney<C>>;
 
         fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -839,7 +839,7 @@ pub mod option_minor {
         }
     }
 
-    pub fn deserialize<'de, C: Currency + Clone, D: Deserializer<'de>>(
+    pub fn deserialize<'de, C: Currency, D: Deserializer<'de>>(
         deserializer: D,
     ) -> Result<Option<RawMoney<C>>, D::Error> {
         deserializer.deserialize_option(Visitor(PhantomData))


### PR DESCRIPTION
Avoid making Currency extend Clone.

This PR is intended to remove dependency on `Clone` everywhere `Currency` defined. 
Currently where `Currency` defined, `Clone` needed to be extended too(`: Currency + Clone`) because Money and RawMoney previously derive `Clone`. 

Any type parameter with type `Currency` doesn't need to extend `Clone` as it doesn't need it.